### PR TITLE
Draft: add multimodal retriever wrapper as first draft

### DIFF
--- a/mdb_toolkit/InputHandler.py
+++ b/mdb_toolkit/InputHandler.py
@@ -1,15 +1,10 @@
-import numpy as np
-from voyageai import Client
 from abc import ABC, abstractmethod
-import boto3
 from botocore.exceptions import NoCredentialsError
 from io import BytesIO
 
 import fitz  # PyMuPDF
 from PIL import Image
 
-
-MODEL_NAME = "voyage-multimodal-3"
 
 def upload_to_s3(local_file, s3_client, bucket_name, s3_key):
     try:
@@ -109,87 +104,3 @@ class PDFHandler(S3PDFHandler):
         return super().preprocess(s3_client, f"s3://{self.bucket_name}/{file_name}") 
 
 
-
-
-
-
-class MultiModalRetriever():
-    def __init__(self, mongo_client, database_name, collection_name, index_name, s3_client, bucket_name, voyage_api_key):
-        self.client = mongo_client
-        self.database_name = database_name
-        self.collection_name = collection_name
-        self.index_name = index_name
-        self.s3 = s3_client
-        self.bucket_name = bucket_name
-        self.vo = self._get_voyage_client(voyage_api_key)
-
-
-    def _get_voyage_client(self, voyage_api_key):
-        return Client(api_key=voyage_api_key)
-
-
-    def _create_input_processor(self, input):
-        input_format = "pdf"
-        if input.startswith("s3://"):
-            if input.endswith(".pdf"):
-                return S3PDFHandler()
-            else:
-                return S3ImageHandler()
-        else: 
-            if input.endswith(".pdf"):
-                return PDFHandler(bucket_name=self.bucket_name)
-            else:
-                return ImageHandler(bucket_name=self.bucket_name)
-    
-    
-    def _create_embedding(self, processed_inputs):
-        # handle parsing out images from pdfs, and/or pulling images from s3
-        # create and return the actual embeddings
-        return np.array(
-            self.vo.multimodal_embed(
-            inputs=[[x] for x in processed_inputs],
-            model=MODEL_NAME,
-            input_type="document"
-        ).embeddings)
-
-    def _store_embedding(self, document_vectors, metadata):
-        # store the embeddings in mongodb alongside the 
-        # file metadata in S3
-        for i, doc_vector in enumerate(document_vectors):
-            self.client[self.database_name][self.collection_name].insert_one({
-                "s3_full_path": metadata["s3_full_path"],
-                "s3_bucket_name": metadata["s3_bucket_name"],
-                "s3_key": metadata["s3_key"],
-                "content_embedding": doc_vector.tolist()
-            })
-        return True
-
-    def mm_embed(self, inputs):
-        # main entry point for the multimodal retriever utility
-        # establishes embeddings for the input files and saves them
-        # to mongodb
-
-        for input_file in inputs:
-            handler = self._create_input_processor(input_file)
-            processed_inputs, metadata = handler.preprocess(self.s3, input_file)
-            document_vectors = self._create_embedding(processed_inputs)
-            self._store_embedding(document_vectors, metadata)
-        
-        return True
-        
-
-    def mm_query(self, query, k=5):
-        # query the multimodal retriever for the most similar
-        # documents to the query
-        vector_results = self.client.vector_search(
-            query=query,
-            limit=k,
-            database_name=self.database_name,
-            collection_name=self.collection_name,
-            index_name=self.index_name,
-            embedding_field="content_embedding", #voyageai :)
-        )
-        return vector_results
-
-
-        

--- a/mdb_toolkit/MultiModalRetriever.py
+++ b/mdb_toolkit/MultiModalRetriever.py
@@ -1,0 +1,87 @@
+import numpy as np
+from voyageai import Client
+from mdb_toolkit.InputHandler import PDFHandler, ImageHandler, S3PDFHandler, S3ImageHandler
+
+MODEL_NAME = "voyage-multimodal-3"
+
+
+class MultiModalRetriever():
+    def __init__(self, mongo_client, database_name, collection_name, index_name, s3_client, bucket_name, voyage_api_key):
+        self.client = mongo_client
+        self.database_name = database_name
+        self.collection_name = collection_name
+        self.index_name = index_name
+        self.s3 = s3_client
+        self.bucket_name = bucket_name
+        self.vo = self._get_voyage_client(voyage_api_key)
+
+
+    def _get_voyage_client(self, voyage_api_key):
+        return Client(api_key=voyage_api_key)
+
+
+    def _create_input_processor(self, input):
+        input_format = "pdf"
+        if input.startswith("s3://"):
+            if input.endswith(".pdf"):
+                return S3PDFHandler()
+            else:
+                return S3ImageHandler()
+        else: 
+            if input.endswith(".pdf"):
+                return PDFHandler(bucket_name=self.bucket_name)
+            else:
+                return ImageHandler(bucket_name=self.bucket_name)
+    
+    
+    def _create_embedding(self, processed_inputs):
+        # handle parsing out images from pdfs, and/or pulling images from s3
+        # create and return the actual embeddings
+        return np.array(
+            self.vo.multimodal_embed(
+            inputs=[[x] for x in processed_inputs],
+            model=MODEL_NAME,
+            input_type="document"
+        ).embeddings)
+
+    def _store_embedding(self, document_vectors, metadata):
+        # store the embeddings in mongodb alongside the 
+        # file metadata in S3
+        for i, doc_vector in enumerate(document_vectors):
+            self.client[self.database_name][self.collection_name].insert_one({
+                "s3_full_path": metadata["s3_full_path"],
+                "s3_bucket_name": metadata["s3_bucket_name"],
+                "s3_key": metadata["s3_key"],
+                "content_embedding": doc_vector.tolist()
+            })
+        return True
+
+    def mm_embed(self, inputs):
+        # main entry point for the multimodal retriever utility
+        # establishes embeddings for the input files and saves them
+        # to mongodb
+
+        for input_file in inputs:
+            handler = self._create_input_processor(input_file)
+            processed_inputs, metadata = handler.preprocess(self.s3, input_file)
+            document_vectors = self._create_embedding(processed_inputs)
+            self._store_embedding(document_vectors, metadata)
+        
+        return True
+        
+
+    def mm_query(self, query, k=5):
+        # query the multimodal retriever for the most similar
+        # documents to the query
+        vector_results = self.client.vector_search(
+            query=query,
+            limit=k,
+            database_name=self.database_name,
+            collection_name=self.collection_name,
+            index_name=self.index_name,
+            embedding_field="content_embedding", #voyageai :)
+        )
+        return vector_results
+
+
+        

--- a/mdb_toolkit/__init__.py
+++ b/mdb_toolkit/__init__.py
@@ -6,9 +6,11 @@ logger = logging.getLogger(__name__)
 logger.info("Initializing mdb_toolkit package")
 
 from .core import CustomMongoClient, Node, Edge
+from .MultiModalRetriever import MultiModalRetriever
 
 __all__ = [
     'CustomMongoClient',
     'Node',
-    'Edge'
+    'Edge',
+    'MultiModalRetriever'
 ]

--- a/scripts/MultiModalRetriever.py
+++ b/scripts/MultiModalRetriever.py
@@ -1,0 +1,199 @@
+import numpy as np
+from voyageai import Client
+from abc import ABC, abstractmethod
+import boto3
+from botocore.exceptions import NoCredentialsError
+from io import BytesIO
+
+import fitz  # PyMuPDF
+from PIL import Image
+
+
+MODEL_NAME = "voyage-multimodal-3"
+
+def upload_to_s3(local_file, s3_client, bucket_name, s3_key):
+    try:
+        s3_client.upload_file(local_file, bucket_name, s3_key)
+        print(f"Upload Successful: {local_file} to s3://{bucket_name}/{s3_key}")
+        return True
+    except FileNotFoundError:
+        print(f"The file {local_file} was not found")
+        return False
+    except NoCredentialsError:
+        print("Credentials not available")
+        return False
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        return False
+
+
+class InputHandler(ABC):
+    @abstractmethod
+    def preprocess(self, input):
+        pass
+
+    def parse_metadata(self, input):
+        file_metadata = {}
+        bucket_name = input.split("/")[2]
+        s3_key = "/".join(input.split("/")[3:])
+
+        file_metadata["s3_full_path"] = input
+        file_metadata["s3_bucket_name"] = bucket_name
+        file_metadata["s3_key"] = s3_key
+        return file_metadata
+        
+
+class S3PDFHandler(InputHandler):
+
+    def _pdf_to_screenshots(self, s3_client, bucket_name, s3_key, zoom=3.0):
+        # open the PDF from S3 and extract the images
+        pdf_data = s3_client.get_object(Bucket=bucket_name, Key=s3_key)["Body"].read()
+
+        pdf_stream = BytesIO(pdf_data)
+        pdf = fitz.open(stream=pdf_stream, filetype="pdf")
+
+        images = []
+
+        # Loop through each page, render as pixmap, and convert to PIL Image
+        mat = fitz.Matrix(zoom, zoom)
+        for n in range(pdf.page_count):
+            pix = pdf[n].get_pixmap(matrix=mat)
+
+            # Convert pixmap to PIL Image
+            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+            images.append(img)
+
+        # Close the document
+        pdf.close()
+        return images
+    
+
+    def preprocess(self, s3_client, input):
+        file_metadata = super.parse_metadata(input)
+        images = self._pdf_to_screenshots(s3_client, file_metadata["bucket_name"], file_metadata["s3_key"])
+        
+        return images, file_metadata
+
+
+class S3ImageHandler(InputHandler):
+
+    def _open_s3_image(self, s3_client, bucket_name, s3_key):
+        image_data = s3_client.get_object(Bucket=bucket_name, Key=s3_key)["Body"].read()
+        img = Image.open(BytesIO(image_data))
+        return img
+    
+    def preprocess(self, s3_client, input):
+        file_metadata = super.parse_metadata(input)
+        image = self._open_s3_image(s3_client, file_metadata["bucket_name"], file_metadata["s3_key"])
+        
+        return [image], file_metadata
+
+class ImageHandler(S3ImageHandler):
+    def __init__(self, bucket_name):
+        super().__init__()
+        self.bucket_name = bucket_name
+
+    def preprocess(self, s3_client, input):
+        file_name = input.split("/")[-1]
+        upload_to_s3(input, s3_client, self.bucket_name, file_name)
+        return super().preprocess(s3_client, f"s3://{self.bucket_name}/{file_name}") 
+
+class PDFHandler(S3PDFHandler):
+    def __init__(self, bucket_name):
+        super().__init__()
+        self.bucket_name = bucket_name
+
+    def preprocess(self, s3_client, input):
+        file_name = input.split("/")[-1]
+        upload_to_s3(input, s3_client, self.bucket_name, file_name)
+        return super().preprocess(s3_client, f"s3://{self.bucket_name}/{file_name}") 
+
+
+
+
+
+
+class MultiModalRetriever():
+    def __init__(self, mongo_client, database_name, collection_name, index_name, bucket_name, voyage_api_key):
+        self.client = mongo_client
+        self.database_name = database_name
+        self.collection_name = collection_name
+        self.index_name = index_name
+        self.s3 = self._get_S3_client()
+        self.bucket_name = bucket_name
+        self.vo = self._get_voyage_client(voyage_api_key)
+
+
+    def _get_S3_client(self):
+        # establish connection to S3
+        return boto3.client('s3')
+
+    def _get_voyage_client(self, voyage_api_key):
+        return Client(api_key=voyage_api_key)
+
+
+    def _create_input_processor(self, input):
+        input_format = "pdf"
+        if input.startswith("s3://"):
+            if input.endswith(".pdf"):
+                return self.S3PDFHandler()
+            else:
+                return self.S3ImageHandler()
+        else: 
+            if input.endswith(".pdf"):
+                return self.PDFHandler(bucket_name=self.bucket_name)
+            else:
+                return self.ImageHandler(bucket_name=self.bucket_name)
+    
+    
+    def _create_embedding(self, processed_inputs):
+        # handle parsing out images from pdfs, and/or pulling images from s3
+        # create and return the actual embeddings
+        return np.array(
+            self.vo.multimodal_embed(
+            inputs=[[x] for x in processed_inputs],
+            model=MODEL_NAME,
+            input_type="document"
+        ).embeddings)
+
+    def _store_embedding(self, document_vectors, metadata):
+        # store the embeddings in mongodb alongside the 
+        # file metadata in S3
+        for i, doc_vector in enumerate(document_vectors):
+            self.mongo_client.insert_one({
+                "s3_full_path": metadata["s3_full_path"],
+                "s3_bucket_name": metadata["s3_bucket_name"],
+                "s3_key": metadata["s3_key"],
+                "content_embedding": doc_vector.tolist()
+            })
+        return True
+
+    def mm_embed(self, inputs):
+        # main entry point for the multimodal retriever utility
+        # establishes embeddings for the input files and saves them
+        # to mongodb
+
+        for input_file in inputs:
+            handler = self._create_input_processor(input_file)
+            processed_inputs, metadata = handler.preprocess(input_file)
+            document_vectors = self._create_embedding(processed_inputs)
+            self._store_embedding(document_vectors, metadata)
+        
+        return True
+        
+
+    def mm_query(self, query, k=5):
+        # query the multimodal retriever for the most similar
+        # documents to the query
+        vector_results = self.mongo_client.vector_search(
+            query=query,
+            limit=k,
+            database_name=self.database_name,
+            collection_name=self.collection_name,
+            index_name=self.index_name,
+            embedding_field="content_embedding", #voyageai :)
+        )
+        pass
+
+
+        

--- a/scripts/demo_voyageai-multimodal-with-s3.py
+++ b/scripts/demo_voyageai-multimodal-with-s3.py
@@ -2,6 +2,7 @@ import logging
 import openai
 from typing import List
 from MultiModalRetriever import MultiModalRetriever
+import voyageai
 
 # load .ENV file
 from dotenv import load_dotenv
@@ -12,7 +13,16 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 import voyageai
-voyageai_api_key = "pa-"
+voyageai_api_key = "<VOYAGEAI_API_KEY>"
+MODEL_NAME = "voyage-multimodal-3"
+vo = voyageai.Client(api_key=voyageai_api_key)
+
+# Setup S3
+import boto3
+access_key = '<AWS_ACCESS_KEY>'
+secret_key = '<AWS_SECRET_KEY>'
+session_token = '<AWS_SESSION_TOKEN>'
+s3_client = boto3.client('s3', aws_access_key_id=access_key, aws_secret_access_key=secret_key, aws_session_token=session_token)
 
 
 # Get Embedding Function
@@ -47,6 +57,7 @@ retriever = MultiModalRetriever(
     database_name=database_name,
     collection_name=collection_name,
     index_name=index_name,
+    s3_client=s3_client,
     bucket_name="test_bucket",
     voyage_api_key=voyageai_api_key
 )
@@ -78,7 +89,7 @@ else:
     print("Index creation process exceeded wait limit.")
     exit()
 
-pdfs = ["my_test.pdf", "my_test2.pdf", "my_test3.pdf"]
+pdfs = ["s3://multimodal-rag-test-jz/fdr-readingcopy.pdf"]
 
 
 # Insert documents into the collection
@@ -99,10 +110,4 @@ logger.info(f"Performing vector-based search with query: '{query}'")
 vector_results = retriever.mm_query(query, k=3)
 print("\n--- Vector-Based Search Results ---")
 for doc in vector_results:
-    print(doc)
-    #print(f"ID: {doc.get('_id')}\nContent: {doc.get('content')}\nMeta Data: {doc.get('meta_data')}\nScore: {doc.get('score')}\n")
-
-
-"""
-output TBD
-"""
+    print(f"ID: {doc.get('_id')}\nS3 Path: {doc.get('s3_full_path')}\nScore: {doc.get('score')}\n")

--- a/scripts/demo_voyageai-multimodal-with-s3.py
+++ b/scripts/demo_voyageai-multimodal-with-s3.py
@@ -1,7 +1,6 @@
 import logging
-import openai
 from typing import List
-from MultiModalRetriever import MultiModalRetriever
+from mdb_toolkit.MultiModalRetriever import MultiModalRetriever
 import voyageai
 
 # load .ENV file

--- a/scripts/demo_voyageai-multimodal-with-s3.py
+++ b/scripts/demo_voyageai-multimodal-with-s3.py
@@ -1,0 +1,108 @@
+import logging
+import openai
+from typing import List
+from MultiModalRetriever import MultiModalRetriever
+
+# load .ENV file
+from dotenv import load_dotenv
+load_dotenv()
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+import voyageai
+voyageai_api_key = "pa-"
+
+
+# Get Embedding Function
+def get_embedding(text: any) -> List[float]:
+    try:
+        # Embed the documents
+        return vo.multimodal_embed(
+            [[text]], model=MODEL_NAME, input_type="document"
+        ).embeddings[0]
+    except Exception as e:
+        logger.error(f"Error generating embedding: {str(e)}")
+        raise
+
+# Example usage
+from mdb_toolkit import CustomMongoClient
+print("mdb_toolkit package imported successfully")
+
+# Define database and collection names
+database_name = "test_database"
+collection_name = "test_collection"
+index_name = "vs_1"  # Ensure this matches your intended index name
+distance_metric = "cosine"
+
+client = CustomMongoClient(
+    "mongodb://localhost:27017/?directConnection=true&serverSelectionTimeoutMS=2000",
+    get_embedding=get_embedding
+)
+
+# Create the MultiModalRetriever instance
+retriever = MultiModalRetriever(
+    mongo_client=client,
+    database_name=database_name,
+    collection_name=collection_name,
+    index_name=index_name,
+    bucket_name="test_bucket",
+    voyage_api_key=voyageai_api_key
+)
+
+# Create the search index
+client._create_search_index(
+    database_name=database_name,
+    collection_name=collection_name,
+    index_name=index_name,
+    distance_metric=distance_metric,
+    embedding_field="content_embedding", #voyageai :)
+)
+
+# Wait for the search index to be READY
+logger.info("Waiting for the search index to be READY...")
+index_ready = client.wait_for_index_ready(
+    database_name=database_name,
+    collection_name=collection_name,
+    index_name=index_name,
+    max_attempts=10,
+    wait_seconds=1
+)
+
+if index_ready:
+    logger.info(f"Search index '{index_name}' is now READY and available!")
+    print("Index is ready!")
+else:
+    logger.error("Index creation process exceeded wait limit or failed.")
+    print("Index creation process exceeded wait limit.")
+    exit()
+
+pdfs = ["my_test.pdf", "my_test2.pdf", "my_test3.pdf"]
+
+
+# Insert documents into the collection
+retriever.mm_embed(pdfs)
+
+print("Inserted documents into the collection.")
+
+# insert pause to allow index update
+import time
+time.sleep(5)
+print("Searching for documents...")
+
+# Perform Multimodal search
+# 1. Vector-Based Search
+query = "The consequences of a dictator's peace"
+logger.info(f"Performing vector-based search with query: '{query}'")
+
+vector_results = retriever.mm_query(query, k=3)
+print("\n--- Vector-Based Search Results ---")
+for doc in vector_results:
+    print(doc)
+    #print(f"ID: {doc.get('_id')}\nContent: {doc.get('content')}\nMeta Data: {doc.get('meta_data')}\nScore: {doc.get('score')}\n")
+
+
+"""
+output TBD
+"""


### PR DESCRIPTION
This MR adds a step to directly support multimodal RAG with S3 as the storage engine. There is a new class, `MultiModalRetriever` that takes in a MongoDB client, an S3 client, and a Voyage AI client to establish a direct embedding and vector search on PDF/Image files, as well as text. 

Clients can call the `mm_embed` function to directly calculate and store an embedding on their files stored in S3. When they call the `mm_query` function the mongo vector search results will be enriched with the S3 path data. That way users don't need to do any additional preprocessing (text or image extraction, for ex) on PDFs or images before creating embeddings.

Todos:
- [x] establish image and pdf support from S3 with metadata in mongo
- [x] establish image and pdf support from local files (with S3 autosave)
- [x] move handlers to their own file
- [x] move main utility to it’s own file alongside core
- [ ] add text support alongside PDF/Images
- [ ] add tests